### PR TITLE
Allow Image to have children

### DIFF
--- a/src/FitImage.js
+++ b/src/FitImage.js
@@ -13,6 +13,10 @@ const propTypes = {
   originalWidth: PropTypes.number,
   source: PropTypes.object.isRequired,
   style: Image.propTypes.style,
+  children: PropTypes.oneOfType([
+    React.PropTypes.arrayOf(React.PropTypes.node),
+    React.PropTypes.node,
+  ]),
 };
 
 class FitImage extends Component {
@@ -102,7 +106,9 @@ class FitImage extends Component {
           this.getStyle(),
         ]}
         onLayout={(event) => this.resize(event)}
-      />
+      >
+        {children}
+      </Image>
     );
   }
 }

--- a/src/FitImage.js
+++ b/src/FitImage.js
@@ -107,7 +107,7 @@ class FitImage extends Component {
         ]}
         onLayout={(event) => this.resize(event)}
       >
-        {children}
+        {this.props.children}
       </Image>
     );
   }


### PR DESCRIPTION
By allowing children in FitImage you can overlay icons, text, etc over an image.
