### PR TITLE
Call onload if passed as prop

### DIFF
--- a/src/FitImage.js
+++ b/src/FitImage.js
@@ -78,6 +78,10 @@ class FitImage extends Image {
 
   onLoad() {
     this.setState({ isLoading: false });
+
+    if(typeof this.props.onLoad === 'function') {
+      this.props.onLoad();
+    }
   }
 
   onLoadStart() {


### PR DESCRIPTION
I was running an animation when the image loaded, and your otherwise great fit-image component didn't call my onLoad callback. This PR calls onLoad if passed as a prop. The same thing could also be extended to onLoadEnd.

Thanks!