### PR TITLE
Fix View rendering error - flexBasis

### DIFF
--- a/src/FitImage.js
+++ b/src/FitImage.js
@@ -117,7 +117,7 @@ class FitImage extends Image {
     if (this.style && this.style.width) {
       return { width: this.style.width };
     }
-    return { flex: 1 };
+    return { flexGrow: 1 };
   }
 
   resize(event) {


### PR DESCRIPTION
This fixes the error 

```
View was rendered with explicitly set width/height but with a 0 flexBasis. (This might be fixed by changing flex: to flexGrow:)
```

The error is specified in `RCTShadowView.m` as

```objectivec
#if RCT_DEBUG
  // This works around a breaking change in css-layout where setting flexBasis needs to be set explicitly, instead of relying on flex to propagate.
  // We check for it by seeing if a width/height is provided along with a flexBasis of 0 and the width/height is laid out as 0.
  if ((!CSSValueIsUndefined(CSSNodeStyleGetFlexBasis(node)) && CSSNodeStyleGetFlexBasis(node) == 0) &&
      ((!CSSValueIsUndefined(CSSNodeStyleGetWidth(node)) && CSSNodeStyleGetWidth(node) > 0 && CSSNodeLayoutGetWidth(node) == 0) ||
       (!CSSValueIsUndefined(CSSNodeStyleGetHeight(node)) && CSSNodeStyleGetHeight(node) > 0 && CSSNodeLayoutGetHeight(node) == 0))) {
    RCTLogError(@"View was rendered with explicitly set width/height but with a 0 flexBasis. (This might be fixed by changing flex: to flexGrow:) View: %@", self);
  }
#endif
```