### PR TITLE
Refresh Size When New Image Loads

### DIFF
--- a/src/FitImage.js
+++ b/src/FitImage.js
@@ -72,14 +72,7 @@ class FitImage extends Image {
     if (!this.props.source.uri) return;
 
     this.mounted = true;
-
-    Image.getSize(this.props.source.uri, (originalWidth, originalHeight) => {
-      if (!this.mounted) {
-        return;
-      }
-
-      this.setStateSize(originalWidth, originalHeight);
-    });
+    this.refreshStateSize();
   }
 
   componentWillUnmount() {
@@ -88,8 +81,9 @@ class FitImage extends Image {
 
   onLoad() {
     this.setState({ isLoading: false });
+    this.refreshStateSize();
 
-    if(typeof this.props.onLoad === 'function') {
+    if (typeof this.props.onLoad === 'function') {
       this.props.onLoad();
     }
   }
@@ -137,6 +131,16 @@ class FitImage extends Image {
     this.setState({
       height,
       layoutWidth: width,
+    });
+  }
+
+  refreshStateSize() {
+    Image.getSize(this.props.source.uri, (originalWidth, originalHeight) => {
+      if (!this.mounted) {
+        return;
+      }
+
+      this.setStateSize(originalWidth, originalHeight);
     });
   }
 


### PR DESCRIPTION
Hey great library, solved a big problem for me. I noticed though that the component only retrieves `originalWidth` and `originalHeight` right when the component mounts, so when I change the URI of the `FitImage` it's still using the old URI's size. 

This fixes that by moving the `Image.getSize(...);` stuff out of `componentDidMount` and into it's own method, which gets called in `componentDidMount` and also in the images `onLoad` callback.