### PR TITLE
Check if ImageBackground exist before using

### DIFF
--- a/src/FitImage.js
+++ b/src/FitImage.js
@@ -172,7 +172,7 @@ class FitImage extends Image {
       children = this.renderActivityIndicator();
     }
 
-    if (children) {
+    if (children && ImageBackground) {
       ImageComponent = ImageBackground;
     }
 


### PR DESCRIPTION
* To make it compatible with RN prior to 0.46.x, check if ImageBackground exist before actually using it

Fixes #57 