### PR TITLE
Check if uri is provided before using it

### DIFF
--- a/src/FitImage.js
+++ b/src/FitImage.js
@@ -70,7 +70,6 @@ class FitImage extends Image {
 
   componentDidMount() {
     if (this.props.originalWidth && this.props.originalHeight) return;
-    if (!this.props.source.uri) return;
 
     this.mounted = true;
     this.refreshStateSize();
@@ -136,6 +135,10 @@ class FitImage extends Image {
   }
 
   refreshStateSize() {
+    if (!this.props.source.uri) {
+      return;
+    }
+
     Image.getSize(this.props.source.uri, (originalWidth, originalHeight) => {
       if (!this.mounted) {
         return;


### PR DESCRIPTION
* `Image.getSize` is only for remote images and needs uri to work
properly

Fixes #52 