### PR TITLE
Android endless loader: set isLoading false on image loading error

### DIFF
--- a/src/FitImage.tsx
+++ b/src/FitImage.tsx
@@ -140,6 +140,7 @@ class FitImage extends Component<IFitImageProps, IFitImageState> {
         onLayout={this.onLayout}
         onLoad={this.onLoad}
         onLoadStart={this.onLoadStart}
+        onError={this.onError}
         source={this.props.source}
         style={[
           this.style,
@@ -171,6 +172,12 @@ class FitImage extends Component<IFitImageProps, IFitImageState> {
     if (this.isFirstLoad) {
       this.setState({ isLoading: true });
       this.isFirstLoad = false;
+    }
+  }
+
+  private onError = () => {
+    if (this.state.isLoading) {
+      this.setState({ isLoading: false });
     }
   }
 


### PR DESCRIPTION
Issue description:
- the loader will be shown on Android continuously on getting an error, while loading the invalid uri 

Example of code to reproduce:
```
<FitImage source={{ uri: 'https://octodex.github.com/images/dojocat.png' }} />
```