### PR TITLE
Call onerror prop function if supplied when image errors

### DIFF
--- a/src/FitImage.tsx
+++ b/src/FitImage.tsx
@@ -179,6 +179,10 @@ class FitImage extends Component<IFitImageProps, IFitImageState> {
     if (this.state.isLoading) {
       this.setState({ isLoading: false });
     }
+
+    if (typeof this.props.onError === 'function') {
+      this.props.onError();
+    }
   }
 
   private getHeight = () => {


### PR DESCRIPTION
As title, I've added a check in the onError method to call an onError prop function if supplied as it doesn't currently call one if supplied.